### PR TITLE
[B2BNEWSTOR-1] Update theme with newest B2B Suite features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,23 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `vtex.storefront-permissions-ui@1.x` dependency
+- `vtex.b2b-quotes` dependency and `quotes-locking-modal` block
+- `vtex.b2b-organizations` dependency and `b2b-user-widget` block
+
+### Removed
+
+- `b2bstoreqa.seller-selector-custom` dependency and blocks
+- `vtex.storefront-permissions-ui@0.x` peer dependency
+
 ## [2.1.0] - 2022-04-25
 
 ### Added
+
 - `seller-selector-custom` to PDP
+
 ## [2.0.2] - 2022-02-03
 
 ### Fixed

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,18 +12,16 @@ Before starting with the B2B Store Theme setup itself, you must:
 2. Follow [these instructions](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-2-prerequesites) to make sure you meet all the prerequisites to develop using Store Framework.
 3. Make sure your store’s catalog is integrated with VTEX Intelligent Search, as described in [this article](https://help.vtex.com/en/tracks/vtex-intelligent-search--19wrbB7nEQcmwzDPl1l4Cb/6wKQgKmu2FT6084BJT7z5V).
 
-
 ### Install required B2B apps
 
 Now you must install the required apps listed below. They are mandatory for the B2B Store Theme to work properly.
 
-* [Wishlist](https://developers.vtex.com/vtex-developer-docs/docs/installing-the-b2b-store-theme#wishlist)
-* [Reviews and Ratings](https://developers.vtex.com/vtex-developer-docs/docs/installing-the-b2b-store-theme#reviews-and-ratings)
-* [Quick Order](https://developers.vtex.com/vtex-developer-docs/docs/installing-the-b2b-store-theme#quick-order)
-* [Location Availability](https://developers.vtex.com/vtex-developer-docs/docs/installing-the-b2b-store-theme#location-availability)
-* [Shopper Location](https://developers.vtex.com/vtex-developer-docs/docs/installing-the-b2b-store-theme#shopper-location)
-* [Order Quote](https://developers.vtex.com/vtex-developer-docs/docs/installing-the-b2b-store-theme#order-quote)
-* [Wordpress Integration](https://developers.vtex.com/vtex-developer-docs/docs/installing-the-b2b-store-theme#wordpress-integration)
+- [Wishlist](https://developers.vtex.com/vtex-developer-docs/docs/installing-the-b2b-store-theme#wishlist)
+- [Reviews and Ratings](https://developers.vtex.com/vtex-developer-docs/docs/installing-the-b2b-store-theme#reviews-and-ratings)
+- [Quick Order](https://developers.vtex.com/vtex-developer-docs/docs/installing-the-b2b-store-theme#quick-order)
+- [Location Availability](https://developers.vtex.com/vtex-developer-docs/docs/installing-the-b2b-store-theme#location-availability)
+- [Shopper Location](https://developers.vtex.com/vtex-developer-docs/docs/installing-the-b2b-store-theme#shopper-location)
+- [Wordpress Integration](https://developers.vtex.com/vtex-developer-docs/docs/installing-the-b2b-store-theme#wordpress-integration)
 
 #### Wishlist
 
@@ -39,20 +37,20 @@ vtex install vtex.wish-list@1.x
 
 The [Reviews and ratings](https://github.com/vtex-apps/reviews-and-ratings) app enables your clients to submit reviews and ratings — using a star rating system — to your store’s products.
 
-Install it using the command: 
+Install it using the command:
 
 ```
 vtex install vtex.reviews-and-ratings@2.x
 ```
 
-After that, go to your store's Admin to proceed with the installation. 
+After that, go to your store's Admin to proceed with the installation.
 
 Once you are logged in, follow these steps:
 
 1. Go to the **Account Settings** module.
 2. Click on `Apps`.
-3. Then, click on `My apps`. 
-4. Then, find the **Reviews and Ratings** app card and click on `Settings`. 
+3. Then, click on `My apps`.
+4. Then, find the **Reviews and Ratings** app card and click on `Settings`.
 5. It is recommended that you check the **Display stars in product-rating-summary if there are no reviews** option and uncheck the **Display total reviews number on product-rating-summary block** option, as illustrated below.
 6. Click on the `Save` button.
 
@@ -62,7 +60,7 @@ Once you are logged in, follow these steps:
 
 [Quick Order](https://github.com/vtex-apps/quickorder) is an app that enables customers to make bulk orders.
 
-To install it, use the following command: 
+To install it, use the following command:
 
 ```
  vtex install vtex.quickorder@3.x
@@ -74,29 +72,17 @@ The [Location Availability](https://github.com/vtex-apps/location-availability) 
 
 Install this app on your store using the `vtex.location-availability@0.x ` command.
 
-
 #### Shopper Location
 
 [Shopper Location](https://github.com/vtex-apps/shopper-location) is a geolocation app. Once it is installed, the app tracks the customer’s location, after permission is granted.
 
-To install it, use the following command: 
-
+To install it, use the following command:
 
 ```
 vtex install vtex.shopper-location@0.x
 ```
 
-#### Order Quote
-
-[Order Quote](https://github.com/vtex-apps/order-quote) is an app that allows the B2B customer to save a cart’s information and use it later for any order. 
-
-To install it, use the following command: 
-
-```
-vtex install vtex.orderquote@1.x
-```
-
-#### Wordpress integration 
+#### Wordpress integration
 
 The [Wordpress integration](https://github.com/vtex-apps/wordpress-integration) app enables the account admin to create content on your store’s front through Wordpress’ API.
 
@@ -106,18 +92,17 @@ To install this app, run the following command on the CLI:
 vtex install vtex.wordpress-integration@2.x
 ```
 
-### Install B2B Easy Setup (optional) 
+### Install B2B Easy Setup (optional)
 
 If you are setting up a new store, you can follow the instructions in [this guide](https://developers.vtex.com/vtex-rest-api/docs/installing-b2b-easy-set-up) to quickly set up a test store with sample data using the B2B Easy Setup app.
 
 > 🚨 We strongly advise that you do not run Easy Setup on a production environment. It will make irreversible changes and may delete some previous configurations on your store.
 
-
 ## Installation
 
 After following the steps above, you are ready to install the B2B Store Theme. You must:
 
-1. Run the `vtex install vtex.b2bstore@2.x `command on the CLI.
+1. Run the `vtex install vtex.b2bstore@3.x `command on the CLI.
 2. Run the `vtex browse` command to see the B2B Store Theme on your browser.
 
 Finally, your storefront should look like this:
@@ -127,4 +112,3 @@ Finally, your storefront should look like this:
 ## Customization
 
 After installing the B2B Store Theme, you can customize it according to your store’s business needs. Check our guide on [Customizing the B2B Store Theme](https://developers.vtex.com/vtex-developer-docs/docs/customizing-the-b2b-store-theme) for more information.
-

--- a/manifest.json
+++ b/manifest.json
@@ -18,7 +18,6 @@
     "vtex.quickorder": "3.x",
     "vtex.location-availability": "0.x",
     "vtex.shopper-location": "0.x",
-    "vtex.storefront-permissions-ui": "0.x",
     "vtex.wordpress-integration": "2.x"
   },
   "dependencies": {
@@ -79,8 +78,10 @@
     "vtex.sku-list": "1.x",
     "vtex.condition-layout": "2.x",
     "vtex.seller-selector": "0.x",
-    "b2bstoreqa.seller-selector-custom": "0.x",
-    "vtex.store-newsletter": "1.x"
+    "vtex.store-newsletter": "1.x",
+    "vtex.storefront-permissions-ui": "1.x",
+    "vtex.b2b-quotes": "1.x",
+    "vtex.b2b-organizations": "1.x"
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/store/blocks/header/header.jsonc
+++ b/store/blocks/header/header.jsonc
@@ -17,8 +17,10 @@
     },
     "children": [
       "flex-layout.row#telemarketing",
+      "flex-layout.row#organization",
       "flex-layout.row#desktop",
-      "flex-layout.row#headerStripe"
+      "flex-layout.row#headerStripe",
+      "quotes-locking-modal"
     ]
   },
 
@@ -26,6 +28,14 @@
     "children": ["telemarketing"],
     "props": {
       "blockClass": ["bg-blue-medium"],
+      "fullWidth": true
+    }
+  },
+
+  "flex-layout.row#organization": {
+    "children": ["b2b-user-widget"],
+    "props": {
+      "blockClass": ["bg-fresh-blue-lightest"],
       "fullWidth": true
     }
   },
@@ -130,7 +140,11 @@
   },
 
   "sticky-layout#mobile": {
-    "children": ["flex-layout.row#mobileHeader", "slider-layout#menuLinks"],
+    "children": [
+      "flex-layout.row#mobileHeader",
+      "slider-layout#menuLinks",
+      "quotes-locking-modal"
+    ],
     "props": {
       "blockClass": "headerMobile"
     }

--- a/store/blocks/product.jsonc
+++ b/store/blocks/product.jsonc
@@ -17,7 +17,6 @@
       "flex-layout.row#divider",
       "flex-layout.row#box",
       "product-kit#buy-together",
-      "flex-layout.row#seller-selector-custom",
       "flex-layout.row#description-and-gallery",
       "flex-layout.row#features",
       "flex-layout.row#specification",
@@ -26,38 +25,11 @@
       "flex-layout.row#alsoView"
     ]
   },
-  "flex-layout.row#seller-selector-custom": {
-    "props": {
-      "blockClass": ["seller-selector-custom"]
-    },
-    "children": ["seller-selector-custom"]
-  },
   "responsive-layout.desktop#product": {
     "children": ["flex-layout.row#product", "flex-layout.row#alsoView"]
   },
   "flex-layout.row#product": {
     "children": ["flex-layout.col#product"]
-  },
-  "check-permission#seller-selector-custom": {
-    "props": {
-      "roles": [
-        "store-admin",
-        "sales-admin",
-        "sales-manager",
-        "sales-representative",
-        "customer-admin",
-        "customer-approver",
-        "customer-buyer"
-      ]
-    },
-    "blocks": [
-      "allowed-content#seller-selector-custom"
-    ]
-  },
-  "allowed-content#seller-selector-custom": {
-    "children": [
-      "flex-layout.row#seller-selector-custom"
-    ]
   },
   "flex-layout.col#product": {
     "children": [
@@ -65,7 +37,6 @@
       "flex-layout.row#product-details",
       "product-kit#buy-together", // This block won't work if it's not a direct children of store.product
       "flex-layout.row#description-and-gallery",
-      "check-permission#seller-selector-custom",
       "flex-layout.row#features",
       "flex-layout.row#specification",
       "flex-layout.row#reviews-and-ratings"


### PR DESCRIPTION
#### What problem is this solving?

Updates the B2B Newstore Theme template to depend on the most recent major versions of `storefront-permissions-ui` (which provides permission challenge blocks), `b2b-organizations` (which provides a user widget for the header) and `b2b-quotes` (which provides a modal that is displayed if the user attempts to browse the store while a quote is in their cart). 

This PR also removes the custom app `b2bstoreqa.seller-selector-custom` from the dependencies as this is not an app that should be used by all B2B stores.

#### How to test it?

Linked here: https://arthur--b2bstoreqa.myvtex.com